### PR TITLE
Offseter - Splitting color string of relations to only use first color

### DIFF
--- a/www.opensnowmap.org/offseter/new_offsetter.js
+++ b/www.opensnowmap.org/offseter/new_offsetter.js
@@ -107,7 +107,7 @@ function requestRelations(extent, resolution, projection) {
                     
                     var rel=[];
                     rel['name']=element.name;
-                    rel['color']=element.color;
+                    rel['color']=element.color.split(";")[0];
                     rel['id'] =element.ids[0];
                     
                     if ( ! relationOffsets[ rel['id'] ]) {relationOffsets[ rel['id'] ] =0;}
@@ -117,7 +117,7 @@ function requestRelations(extent, resolution, projection) {
                     updateRelationList();
                     
                     var stroke= new ol.style.Stroke({
-                               color: element.color,
+                               color: element.color.split(";")[0],
                                width: 3
                              });
                     var style = new ol.style.Style({


### PR DESCRIPTION
It is fairly common for the color tag of route=piste relations to have more than one color specified (e.g. "#00FF00;#FFFFFF").
Currently the offseter sets the color tag of both the relation text in the piste list and the line object in the map to the string value of the color key of the relation.
The relation text (CSS) in the piste list uses the first hex value (at least in Firefox/Chromium) but the line object in the map does not interpret the multi-valued string in the same way which causes some confusion.

**Example:**
[http://www.opensnowmap.org/offseter/index.html#map=14/17.191/60.641/](http://www.opensnowmap.org/offseter/index.html#map=14/17.191/60.641/)
- The relation 2351201 has color="#00FF00;#FFFFFF"
- Text in piste list shown in green.
- Piste line object in map shown in yellow.

This pull request splits the color string (on ";") and only uses the first part of the string. Which, in the example above, results in both text and line in green color.